### PR TITLE
fixes a bug that occurs when trying to open the downloaded model weights

### DIFF
--- a/brainles_aurora/inferer/model.py
+++ b/brainles_aurora/inferer/model.py
@@ -85,7 +85,7 @@ class ModelHandler:
         # load weights
         weights_path = os.path.join(
             self.model_weights_folder,
-            f"{self.inference_mode}_{self.config.model_selection}.tar",
+            f"{self.inference_mode.value}_{self.config.model_selection.value}.tar",
         )
         if not os.path.exists(weights_path):
             raise NotImplementedError(


### PR DESCRIPTION
Fixes the bug that occurs when trying to open the downloaded model weights.

Considering that the model weights are named like `t1-o_best.tar`, the `_load_model` function should look for the value of the `interference_mode` and of the `model_selection`